### PR TITLE
Updating documentation for docker hub

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,51 @@
+# FDNS Business Rules Microservice
+
+Foundation Services (FDNS) Business Rules Microservice is the service used to ingest and validate JSON files.
+
+## Getting Started
+
+To get started with the FDNS Business Rules Microservice you can use either `docker stack deploy` or `docker-compose`:
+
+```yaml
+version: '3.1'
+services:
+  fluentd:
+    image: fluent/fluentd
+    ports:
+      - "24224:24224"
+  fdns-ms-rules:
+    image: cdcgov/fdns-ms-rules
+    ports:
+      - "8083:8083"
+    depends_on:
+      - fluentd
+    environment:
+      RULES_PORT: 8083
+      RULES_FLUENTD_HOST: fluentd
+      RULES_FLUENTD_PORT: 24224
+```
+
+[![Try in PWD](https://raw.githubusercontent.com/play-with-docker/stacks/master/assets/images/button.png)](http://play-with-docker.com?stack=https://raw.githubusercontent.com/CDCgov/fdns-ms-rules/master/stack.yml)
+
+## Source Code
+
+Please see [https://github.com/CDCgov/fdns-ms-rules](https://github.com/CDCgov/fdns-ms-rules) for the fdns-ms-rules source repository.
+
+## Public Domain
+
+This repository constitutes a work of the United States Government and is not subject to domestic copyright protection under 17 USC § 105. This repository is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/). All contributions to this repository will be released under the CC0 dedication.
+
+## License
+
+The repository utilizes code licensed under the terms of the Apache Software License and therefore is licensed under ASL v2 or later.
+
+The container image in this repository is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Apache Software License for more details.
+
+## Privacy
+
+This repository contains only non-sensitive, publicly available data and information. All material and community participation is covered by the Surveillance Platform [Disclaimer](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md) and [Code of Conduct](https://github.com/CDCgov/template/blob/master/code-of-conduct.md).
+For more information about CDC's privacy policy, please visit [http://www.cdc.gov/privacy.html](http://www.cdc.gov/privacy.html).
+
+## Records
+
+This repository is not a source of government records, but is a copy to increase collaboration and collaborative potential. All government records will be published through the [CDC web site](http://www.cdc.gov).

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -16,11 +16,11 @@ services:
   fdns-ms-rules:
     image: cdcgov/fdns-ms-rules
     ports:
-      - "8083:8083"
+      - "8086:8086"
     depends_on:
       - fluentd
     environment:
-      RULES_PORT: 8083
+      RULES_PORT: 8086
       RULES_FLUENTD_HOST: fluentd
       RULES_FLUENTD_PORT: 24224
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 [![Build Status](https://travis-ci.org/CDCgov/fdns-ms-rules.svg?branch=master)](https://travis-ci.org/CDCgov/fdns-ms-rules)
 
 # FDNS Business Rules Microservice
+
 This is the repository with the Business Rules Engine for ingesting and validating JSON files.
 
 ## Running locally
+
 Please read the following instructions carefully for information on how to build, run and test this microservice in your local environment.
 
 ### Before you start
+
 You will need to have the following installed before getting up and running locally:
 
 - Docker, [Installation guides](https://docs.docker.com/install/)
@@ -17,7 +20,7 @@ You will need to have the following installed before getting up and running loca
 
 First you'll need to build the image, to do so just run the following command:
 
-```
+```sh
 make docker-build
 ```
 
@@ -25,7 +28,7 @@ make docker-build
 
 Now you'll be able to run the image, you can easily do so by running the following command:
 
-```
+```sh
 make docker-run
 ```
 
@@ -58,22 +61,23 @@ __Scopes__: This application uses the following scope: `rules.*`
 
 Please see the following environment variables for configuring with your OAuth 2 provider:
 
-* `OAUTH2_ACCESS_TOKEN_URI`: This is the introspection URL of your provider, ex: `https://hydra:4444/oauth2/introspect`
-* `OAUTH2_PROTECTED_URIS`: This is a path for which routes are to be restricted, ex: `/api/1.0/**`
-* `OAUTH2_CLIENT_ID`: This is your OAuth 2 client id with the provider
-* `OAUTH2_CLIENT_SECRET`: This is your OAuth 2 client secret with the provider
-* `SSL_VERIFYING_DISABLE`: This is an option to disable SSL verification, you can disable this when testing locally but this should be set to `false` for all production systems
+- `OAUTH2_ACCESS_TOKEN_URI`: This is the introspection URL of your provider, ex: `https://hydra:4444/oauth2/introspect`
+- `OAUTH2_PROTECTED_URIS`: This is a path for which routes are to be restricted, ex: `/api/1.0/**`
+- `OAUTH2_CLIENT_ID`: This is your OAuth 2 client id with the provider
+- `OAUTH2_CLIENT_SECRET`: This is your OAuth 2 client secret with the provider
+- `SSL_VERIFYING_DISABLE`: This is an option to disable SSL verification, you can disable this when testing locally but this should be set to `false` for all production systems
 
 ### Miscellaneous Configurations
 
 Here are other various configurations and their purposes:
 
-* `RULES_PORT`: This is a configurable port the application is set to run on
-* `RULES_FLUENTD_HOST`: This is the host of your [Fluentd](https://www.fluentd.org/)
-* `RULES_FLUENTD_PORT`: This is the port of your [Fluentd](https://www.fluentd.org/)
-* `RULES_PROXY_HOSTNAME`: This is the hostname of your environment for use with Swagger UI, ex: `api.my.org`
+- `RULES_PORT`: This is a configurable port the application is set to run on
+- `RULES_FLUENTD_HOST`: This is the host of your [Fluentd](https://www.fluentd.org/)
+- `RULES_FLUENTD_PORT`: This is the port of your [Fluentd](https://www.fluentd.org/)
+- `RULES_PROXY_HOSTNAME`: This is the hostname of your environment for use with Swagger UI, ex: `api.my.org`
 
 ## Public Domain
+
 This repository constitutes a work of the United States Government and is not
 subject to domestic copyright protection under 17 USC § 105. This repository is in
 the public domain within the United States, and copyright and related rights in
@@ -83,6 +87,7 @@ submitting a pull request you are agreeing to comply with this waiver of
 copyright interest.
 
 ## License
+
 The repository utilizes code licensed under the terms of the Apache Software
 License and therefore is licensed under ASL v2 or later.
 
@@ -101,6 +106,7 @@ The source code forked from other open source projects will inherit its license.
 
 
 ## Privacy
+
 This repository contains only non-sensitive, publicly available data and
 information. All material and community participation is covered by the
 Surveillance Platform [Disclaimer](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md)
@@ -108,6 +114,7 @@ and [Code of Conduct](https://github.com/CDCgov/template/blob/master/code-of-con
 For more information about CDC's privacy policy, please visit [http://www.cdc.gov/privacy.html](http://www.cdc.gov/privacy.html).
 
 ## Contributing
+
 Anyone is encouraged to contribute to the repository by [forking](https://help.github.com/articles/fork-a-repo)
 and submitting a pull request. (If you are new to GitHub, you might start with a
 [basic tutorial](https://help.github.com/articles/set-up-git).) By contributing
@@ -121,11 +128,13 @@ CDC including this GitHub page are subject to the [Presidential Records Act](htt
 and may be archived. Learn more at [https://www.cdc.gov/other/privacy.html](https://www.cdc.gov/other/privacy.html).
 
 ## Records
+
 This repository is not a source of government records, but is a copy to increase
 collaboration and collaborative potential. All government records will be
 published through the [CDC web site](https://www.cdc.gov).
 
 ## Notices
+
 Please refer to [CDC's Template Repository](https://github.com/CDCgov/template)
 for more information about [contributing to this repository](https://github.com/CDCgov/template/blob/master/CONTRIBUTING.md),
 [public domain notices and disclaimers](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.1'
 services:
   mongo:
     image: mongo

--- a/stack.yml
+++ b/stack.yml
@@ -7,10 +7,10 @@ services:
   fdns-ms-rules:
     image: cdcgov/fdns-ms-rules
     ports:
-      - "8083:8083"
+      - "8086:8086"
     depends_on:
       - fluentd
     environment:
-      RULES_PORT: 8083
+      RULES_PORT: 8086
       RULES_FLUENTD_HOST: fluentd
       RULES_FLUENTD_PORT: 24224

--- a/stack.yml
+++ b/stack.yml
@@ -1,0 +1,16 @@
+version: '3.1'
+services:
+  fluentd:
+    image: fluent/fluentd
+    ports:
+      - "24224:24224"
+  fdns-ms-rules:
+    image: cdcgov/fdns-ms-rules
+    ports:
+      - "8083:8083"
+    depends_on:
+      - fluentd
+    environment:
+      RULES_PORT: 8083
+      RULES_FLUENTD_HOST: fluentd
+      RULES_FLUENTD_PORT: 24224


### PR DESCRIPTION
This pull request updates the README with small fixes for markdown (lines after headers are suggested, etc.).

This also adds a suggested documentation for Docker Hub and adds a stack.yml to be used with http://play-with-docker.com/