### PR TITLE
Updating the OAuth 2.0 Scope Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This microservice is designed to be used with other microservices. Please look a
 
 This microservice is configurable to be secured with an OAuth 2 provider.
 
-__Scopes__: This application uses the following scope: `rules.*`
+__Scopes__: This application uses the following scope: `fdns.rules.{profile}.{create|read|update|delete}`. Example: `fdns.rules.myprofile.read`
 
 Please see the following environment variables for configuring with your OAuth 2 provider:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,10 @@
 version: '3'
 services:
-  mongo:
-    image: mongo
-    ports:
-      - "27017:27017"
   fluentd:
     image: fluent/fluentd
     ports:
       - "24224:24224"
-  fdns-ms-object:
-    image: cdcgov/fdns-ms-object
+  fdns-ms-stubbing:
+    image: cdcgov/fdns-ms-stubbing
     ports:
-      - "8083:8083"
-    environment:
-      OBJECT_PORT: 8083
+      - "3002:3002" 

--- a/src/main/java/gov/cdc/foundation/controller/RulesController.java
+++ b/src/main/java/gov/cdc/foundation/controller/RulesController.java
@@ -62,8 +62,7 @@ public class RulesController {
 	@RequestMapping(method = RequestMethod.GET)
 	@ResponseBody
 	public ResponseEntity<?> index() throws IOException {
-		ObjectMapper mapper = new ObjectMapper();
-		
+		ObjectMapper mapper = new ObjectMapper();		
 		Map<String, Object> log = new HashMap<>();
 		
 		try {
@@ -78,34 +77,62 @@ public class RulesController {
 		}
 	}
 
-
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('rules:'.concat(#profile))")
-	@RequestMapping(value = "{profile}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Create or update rules for the specified profile", notes = "Create or update rules")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #oauth2.hasScope('fdns.rules.'.concat(#profile).concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.rules.'.concat(#profile).concat('.update'))"
+		+ " or #oauth2.hasScope('fdns.rules.'.concat(#profile).concat('.*'))"
+		+ " or #oauth2.hasScope('fdns.rules.*.create')"
+		+ " or #oauth2.hasScope('fdns.rules.*.update')"
+		+ " or #oauth2.hasScope('fdns.rules.*.*')"
+	)
+	@RequestMapping(
+		value = "profile/{profile}",
+		method = RequestMethod.PUT,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Create or update rules for the specified profile",
+		notes = "Create or update rules"
+	)
 	@ResponseBody
 	public ResponseEntity<?> upsertRulesWithPut(
-			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-			@RequestBody(required = true) String payload, 
-			@ApiParam(value = "Profile identifier") @PathVariable(value = "profile") String profile) {
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@RequestBody(required = true) String payload, 
+		@ApiParam(value = "Profile identifier") @PathVariable(value = "profile") String profile
+	) {
 		return upsertRules(authorizationHeader, payload, profile);
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('rules:'.concat(#profile))")
-	@RequestMapping(value = "{profile}", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Create or update rules for the specified profile", notes = "Create or update rules")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #oauth2.hasScope('fdns.rules.'.concat(#profile).concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.rules.'.concat(#profile).concat('.update'))"
+		+ " or #oauth2.hasScope('fdns.rules.'.concat(#profile).concat('.*'))"
+		+ " or #oauth2.hasScope('fdns.rules.*.create')"
+		+ " or #oauth2.hasScope('fdns.rules.*.update')"
+		+ " or #oauth2.hasScope('fdns.rules.*.*')"
+	)
+	@RequestMapping(
+		value = "profile/{profile}",
+		method = RequestMethod.POST,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Create or update rules for the specified profile",
+		notes = "Create or update rules"
+	)
 	@ResponseBody
 	public ResponseEntity<?> upsertRules(
-			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-			@RequestBody(required = true) String payload, 
-			@ApiParam(value = "Profile identifier") @PathVariable(value = "profile") String profile) {
-
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@RequestBody(required = true) String payload, 
+		@ApiParam(value = "Profile identifier") @PathVariable(value = "profile") String profile
+	) {
 		ObjectMapper mapper = new ObjectMapper();
-
 		Map<String, Object> log = new HashMap<>();
 		log.put(MessageHelper.CONST_METHOD, MessageHelper.METHOD_UPSERTRULES);
 
 		try {
-
 			// First, check the profile ID
 			Pattern p = Pattern.compile(profileRegex);
 			if (!p.matcher(profile).matches())
@@ -132,16 +159,28 @@ public class RulesController {
 
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('rules:'.concat(#profile))")
-	@RequestMapping(value = "{profile}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Get saved rules for the specified profile", notes = "Get saved rules")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #oauth2.hasScope('fdns.rules.'.concat(#profile).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.rules.'.concat(#profile).concat('.*'))"
+		+ " or #oauth2.hasScope('fdns.rules.*.read')"
+		+ " or #oauth2.hasScope('fdns.rules.*.*')"
+	)
+	@RequestMapping(
+		value = "profile/{profile}",
+		method = RequestMethod.GET,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Get saved rules for the specified profile",
+		notes = "Get saved rules"
+	)
 	@ResponseBody
 	public ResponseEntity<?> getRules(
-			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-			@ApiParam(value = "Profile identifier") @PathVariable(value = "profile") String profile) {
-
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@ApiParam(value = "Profile identifier") @PathVariable(value = "profile") String profile
+	) {
 		ObjectMapper mapper = new ObjectMapper();
-
 		Map<String, Object> log = new HashMap<>();
 		log.put(MessageHelper.CONST_METHOD, MessageHelper.METHOD_GETRULES);
 
@@ -163,9 +202,23 @@ public class RulesController {
 
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('rules:'.concat(#profile))")
-	@RequestMapping(value = "validate/{profile}", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Validate JSON message", notes = "Valides a JSON object with a stored configuration.")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #oauth2.hasScope('fdns.rules.'.concat(#profile).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.rules.'.concat(#profile).concat('.*'))"
+		+ " or #oauth2.hasScope('fdns.rules.*.read')"
+		+ " or #oauth2.hasScope('fdns.rules.*.*')"
+	)
+	@RequestMapping(
+		value = "validate/{profile}",
+		method = RequestMethod.POST,
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Validate JSON message",
+		notes = "Valides a JSON object with a stored configuration."
+	)
 	@ResponseBody
 	public ResponseEntity<?> validate(
 			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
@@ -218,12 +271,22 @@ public class RulesController {
 		}
 	}
 
-	@RequestMapping(value = "validate", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Validate JSON message", notes = "Valides a JSON object with a provided configuration.")
+	@RequestMapping(
+		value = "validate",
+		method = RequestMethod.POST,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Validate JSON message",
+		notes = "Valides a JSON object with a provided configuration."
+	)
 	@ResponseBody
-	public ResponseEntity<?> validate(@ApiParam(value = "JSON file to validate") @RequestParam("json") MultipartFile json, @ApiParam(value = "Rules configuration") @RequestParam("rules") MultipartFile rules, @RequestParam(defaultValue = "false") boolean explain) {
+	public ResponseEntity<?> validate(
+		@ApiParam(value = "JSON file to validate") @RequestParam("json") MultipartFile json,
+		@ApiParam(value = "Rules configuration") @RequestParam("rules") MultipartFile rules,
+		@RequestParam(defaultValue = "false") boolean explain
+	) {
 		ObjectMapper mapper = new ObjectMapper();
-
 		Map<String, Object> log = new HashMap<>();
 		log.put(MessageHelper.CONST_METHOD, MessageHelper.METHOD_VALIDATE);
 

--- a/src/main/java/gov/cdc/foundation/security/OAuth2Configuration.java
+++ b/src/main/java/gov/cdc/foundation/security/OAuth2Configuration.java
@@ -34,7 +34,7 @@ public class OAuth2Configuration extends ResourceServerConfigurerAdapter {
 			http
 				.authorizeRequests()
 				.antMatchers(HttpMethod.OPTIONS).permitAll()
-				.antMatchers(protectedURIs).access("#oauth2.hasScope('rules')")
+				.antMatchers(protectedURIs).access("#oauth2.hasScope('fdns.rules')")
 				.anyRequest().permitAll();
 		else
 			http

--- a/src/test/java/gov/cdc/foundation/OAuth2Test.java
+++ b/src/test/java/gov/cdc/foundation/OAuth2Test.java
@@ -2,6 +2,7 @@ package gov.cdc.foundation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,16 +12,22 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
+import gov.cdc.helper.RequestHelper;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = { 
 		"logging.fluentd.host=fluentd", 
 		"logging.fluentd.port=24224", 
-		"proxy.hostname=localhost",
-		"security.oauth2.resource.user-info-uri=",
-		"security.oauth2.protected=/**",
-		"security.oauth2.client.client-id=",
-		"security.oauth2.client.client-secret=",
+		"proxy.hostname=",
+		"security.oauth2.resource.user-info-uri=http://fdns-ms-stubbing:3002/oauth2/token/introspect",
+		"security.oauth2.protected=/api/1.0/**",
+		"security.oauth2.client.client-id=test",
+		"security.oauth2.client.client-secret=testsecret",
 		"ssl.verifying.disable=false" })
 @AutoConfigureMockMvc
 public class OAuth2Test {
@@ -28,11 +35,57 @@ public class OAuth2Test {
 	@Autowired
 	private TestRestTemplate restTemplate;
 	private String baseUrlPath = "/api/1.0/";
+	private String testToken = "Bearer testtoken";
+
+	@Before
+	public void setup() throws Exception {
+		// Define the object URL
+		System.setProperty("OBJECT_URL", "http://fdns-ms-stubbing:3002/object");
+	}
 
 	@Test
-	public void indexPage() {
+	public void testUnauthenticated() {
 		ResponseEntity<String> response = this.restTemplate.getForEntity(baseUrlPath, String.class);
 		assertThat(response.getStatusCodeValue()).isEqualTo(401);
 	}
 
+	@Test
+	public void testAthenticatedSpecific() {
+		setScope("fdns.rules fdns.rules.myprofile.create");
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Authorization", testToken);
+		HttpEntity<String> request = new HttpEntity<String>("{}", headers);
+
+		ResponseEntity<String> response = this.restTemplate.exchange(
+			baseUrlPath + "profile/myprofile",
+			HttpMethod.POST,
+			request, 
+			String.class
+		);
+		assertThat(response.getStatusCodeValue()).isEqualTo(200);
+	}
+
+	@Test
+	public void testAthenticatedWildcard() {
+		setScope("fdns.rules fdns.rules.*.*");
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Authorization", testToken);
+		HttpEntity<String> request = new HttpEntity<String>("{}", headers);
+
+		ResponseEntity<String> response = this.restTemplate.exchange(
+			baseUrlPath + "profile/myprofile",
+			HttpMethod.POST,
+			request, 
+			String.class
+		);
+		assertThat(response.getStatusCodeValue()).isEqualTo(200);
+	}
+
+	private void setScope(String scope) {
+		MultiValueMap<String, String> data = new LinkedMultiValueMap<>();
+		data.add("scope", scope);
+		RequestHelper.getInstance().executePost("http://fdns-ms-stubbing:3002/oauth2/mock", data);
+	}
 }

--- a/src/test/java/gov/cdc/foundation/RulesApplicationTests.java
+++ b/src/test/java/gov/cdc/foundation/RulesApplicationTests.java
@@ -41,7 +41,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = { 
 		"logging.fluentd.host=fluentd", 
 		"logging.fluentd.port=24224", 
-		"proxy.hostname=localhost",
+		"proxy.hostname=",
 		"security.oauth2.resource.user-info-uri=",
 		"security.oauth2.protected=",
 		"security.oauth2.client.client-id=",
@@ -64,7 +64,7 @@ public class RulesApplicationTests {
 		JacksonTester.initFields(this, objectMapper);
 
 		// Define the object URL
-		System.setProperty("OBJECT_URL", "http://fdns-ms-object:8083");
+		System.setProperty("OBJECT_URL", "http://fdns-ms-stubbing:3002/object");
 	}
 
 	@Test
@@ -140,7 +140,7 @@ public class RulesApplicationTests {
 		
 		for (int i = 0; i < nbOfCalls; i++) {
 			ResponseEntity<JsonNode> response = restTemplate.exchange(
-					baseUrlPath + "{profile}", 
+					baseUrlPath + "profile/{profile}", 
 					HttpMethod.POST, 
 					getEntity(getResourceAsString("junit/rules.json"), MediaType.APPLICATION_JSON),
 					JsonNode.class,
@@ -160,7 +160,7 @@ public class RulesApplicationTests {
 		createAndUpdateRules();
 		
 		ResponseEntity<JsonNode> response = restTemplate.exchange(
-				baseUrlPath + "{profile}", 
+				baseUrlPath + "profile/{profile}", 
 				HttpMethod.GET, 
 				null,
 				JsonNode.class,
@@ -184,5 +184,4 @@ public class RulesApplicationTests {
 		HttpEntity<String> entity = new HttpEntity<String>(content, headers);
 		return entity;
 	}
-
 }


### PR DESCRIPTION
This pull request proposes a few changes:

- Changing the scopes to fall under a `fdns.*` namespace
- Adds support for CRUD operations (create, read, update and delete) and appends it at the end of the scope
- Adds support for wildcard scopes
- Adds the new https://github.com/CDCgov/fdns-ms-stubbing service for unit testing and tests OAuth 2.0 functionality